### PR TITLE
Update poetry installation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ workon kurby
 ````
 ### Install poetry
 ```bash
-curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python -
+curl -sSL https://install.python-poetry.org | python3 -
 ```
 ### Install dependencies using poetry
 ```bash


### PR DESCRIPTION
The poetry installation command included a dead link. I fixed it up for you using their latest command `curl -sSL https://install.python-poetry.org | python3 -`

Have a nice day aberrier :)